### PR TITLE
 Blamed location is wrong when return type annotation is violated #15

### DIFF
--- a/python/deps/untypy/test/impl/test_bound_generic.py
+++ b/python/deps/untypy/test/impl/test_bound_generic.py
@@ -35,7 +35,7 @@ class TestBoundGeneric(unittest.TestCase):
         with self.assertRaises(UntypyTypeError) as cm:
             instance.insert("this should be an int")
 
-        self.assertTrue("instance.insert" in cm.exception.last_responsable().source_line)
+        self.assertTrue("instance.insert" in cm.exception.last_responsable().source_lines_span())
 
     def test_bound_generic_protocol_style_ok(self):
         instance = Aint()
@@ -99,4 +99,4 @@ class TestBoundGeneric(unittest.TestCase):
         with self.assertRaises(UntypyTypeError) as cm:
             instance.some_string()
 
-        self.assertTrue("def some_string(self) -> T:" in cm.exception.last_responsable().source_line)
+        self.assertTrue("def some_string(self) -> T:" in cm.exception.last_responsable().source_lines_span())

--- a/python/deps/untypy/test/util.py
+++ b/python/deps/untypy/test/util.py
@@ -16,7 +16,7 @@ class DummyExecutionContext(ExecutionContext):
             responsable=Location(
                 file="dummy",
                 line_no=0,
-                source_line="dummy"
+                line_span=1
             )
         ))
 
@@ -27,7 +27,7 @@ class DummyDefaultCreationContext(DefaultCreationContext):
         super().__init__(typevars.copy(), Location(
             file="dummy",
             line_no=0,
-            source_line="dummy"
+            line_span=1
         ), checkedpkgprefixes=["test"])
 
 

--- a/python/deps/untypy/test/util_test/test_return_traces.py
+++ b/python/deps/untypy/test/util_test/test_return_traces.py
@@ -1,0 +1,33 @@
+import ast
+import unittest
+
+from untypy.util.return_traces import ReturnTraceManager, ReturnTracesTransformer
+
+
+class TestAstTransform(unittest.TestCase):
+
+    def test_ast_transform(self):
+        src = """
+def foo(flag: bool) -> int:
+    print('Hello World')
+    if flag:
+        return 1
+    else:
+        return 'you stupid'
+        """
+        target = """
+def foo(flag: bool) -> int:
+    print('Hello World')
+    if flag:
+        untypy._before_return(0)
+        return 1
+    else:
+        untypy._before_return(1)
+        return 'you stupid'
+        """
+
+        tree = ast.parse(src)
+        ReturnTracesTransformer("<dummyfile>", ReturnTraceManager()).visit(tree)
+        ast.fix_missing_locations(tree)
+        self.assertEqual(ast.unparse(tree).strip(), target.strip())
+

--- a/python/deps/untypy/test/util_test/test_return_traces.py
+++ b/python/deps/untypy/test/util_test/test_return_traces.py
@@ -27,7 +27,10 @@ def foo(flag: bool) -> int:
         """
 
         tree = ast.parse(src)
-        ReturnTracesTransformer("<dummyfile>", ReturnTraceManager()).visit(tree)
+        mgr = ReturnTraceManager()
+        ReturnTracesTransformer("<dummyfile>", mgr).visit(tree)
         ast.fix_missing_locations(tree)
         self.assertEqual(ast.unparse(tree).strip(), target.strip())
+        self.assertEqual(mgr.get(0), ("<dummyfile>", 5))
+        self.assertEqual(mgr.get(1), ("<dummyfile>", 7))
 

--- a/python/deps/untypy/untypy/__init__.py
+++ b/python/deps/untypy/untypy/__init__.py
@@ -99,7 +99,7 @@ def enable_on_imports(*prefixes):
 
     transformer = _importhook_transformer_builder
     install_import_hook(predicate, transformer)
-    _exec_module_patched(caller, True, transformer(caller.__name__.split(".")))
+    _exec_module_patched(caller, True, transformer(caller.__name__.split("."), caller.__file__))
 
 
 def _exec_module_patched(mod: ModuleType, exit_after: bool, transformer: ast.NodeTransformer):

--- a/python/deps/untypy/untypy/__init__.py
+++ b/python/deps/untypy/untypy/__init__.py
@@ -13,11 +13,17 @@ from .util.return_traces import ReturnTracesTransformer, before_return, GlobalRe
 from .util.tranformer_combinator import TransformerCombinator
 
 GlobalConfig = DefaultConfig
+
+"""
+This function is called before any return statement, to store which was the last return.
+For this the AST is transformed using ReturnTracesTransformer.
+Must be in untypy so it can be used in transformed module.
+Must also be in other module, so it can be used from inside (No circular imports).
+"""
 _before_return = before_return
 
 _importhook_transformer_builder = lambda path, file: TransformerCombinator(UntypyAstTransformer(),
                                                                            ReturnTracesTransformer(file))
-
 
 def just_install_hook(prefixes=[]):
     def predicate(module_name):

--- a/python/deps/untypy/untypy/error.py
+++ b/python/deps/untypy/untypy/error.py
@@ -112,7 +112,12 @@ class Location:
                     line_span=1
                 )
 
-    def mark(self, reti_loc):
+    def narrow_in_span(self, reti_loc : Tuple[str, int]):
+        """
+        Use new Location if inside of span of this Location
+        :param reti_loc: filename and line_no
+        :return: a new Location, else self
+        """
         file, line = reti_loc
         if self.file == file and line in range(self.line_no, self.line_no + self.line_span):
             return Location(

--- a/python/deps/untypy/untypy/error.py
+++ b/python/deps/untypy/untypy/error.py
@@ -16,10 +16,10 @@ class Location:
         self.file = file
         self.line_no = line_no
         self.line_span = line_span
-        self.source_line = None
+        self.source_lines = None
 
-    def _source(self) -> Optional[str]:
-        if self.source_line is  None:
+    def source(self) -> Optional[str]:
+        if self.source_lines is None:
             try:
                 with open(self.file, "r") as f:
                     self.source_lines = f.read()
@@ -28,9 +28,24 @@ class Location:
 
         return self.source_lines
 
+    def source_lines_span(self) -> Optional[str]:
+        # This is still used for unit testing
+
+        source = self.source()
+        if source is None:
+            return None
+
+        buf = ""
+
+        for i, line in enumerate(source.splitlines()):
+            if (i + 1) in range(self.line_no, self.line_no + self.line_span):
+                buf += f"\n{line}"
+
+        return buf
+
     def __str__(self):
         buf = f"{relpath(self.file)}:{self.line_no}"
-        source = self._source()
+        source = self.source()
         if source is None:
             buf += f"\n{'{:3}'.format(self.line_no)} | <source code not found>"
             return buf

--- a/python/deps/untypy/untypy/error.py
+++ b/python/deps/untypy/untypy/error.py
@@ -78,6 +78,18 @@ class Location:
                     source_line=None
                 )
 
+    def mark(self, reti_loc):
+        file, line = reti_loc
+        lines = self.source_line.splitlines()
+        if self.file == file and line in range(self.line_no, self.line_no + len(lines)):
+            return Location(
+                file=file,
+                line_no=line,
+                source_line=lines[line - self.line_no]
+            )
+        else:
+            return self
+
 
 class Frame:
     type_declared: str

--- a/python/deps/untypy/untypy/error.py
+++ b/python/deps/untypy/untypy/error.py
@@ -2,31 +2,51 @@ from __future__ import annotations
 
 import inspect
 from enum import Enum
+from os.path import relpath
 from typing import Any, Optional, Tuple, Iterable
 
 
 class Location:
     file: str
     line_no: int
-    source_line: str
+    line_span : int
+    source_lines: Optional[str]
 
-    def __init__(self, file: str, line_no: int, source_line: str):
+    def __init__(self, file: str, line_no: int, line_span : int):
         self.file = file
         self.line_no = line_no
-        self.source_line = source_line
+        self.line_span = line_span
+        self.source_line = None
+
+    def _source(self) -> Optional[str]:
+        if self.source_line is  None:
+            try:
+                with open(self.file, "r") as f:
+                    self.source_lines = f.read()
+            except OSError:
+                pass
+
+        return self.source_lines
 
     def __str__(self):
-        buf = f"{self.file}:{self.line_no}"
-        if self.source_line:
-            for i, line in enumerate(self.source_line.splitlines()):
-                if i < 5:
-                    buf += f"\n{'{:3}'.format(self.line_no + i)} | {line}"
-            if i >= 5:
-                buf += "\n    | ..."
+        buf = f"{relpath(self.file)}:{self.line_no}"
+        source = self._source()
+        if source is None:
+            buf += f"\n{'{:3}'.format(self.line_no)} | <source code not found>"
+            return buf
+
+        start = max(self.line_no - 2, 1)
+        end = start + 5
+        for i, line in enumerate(source.splitlines()):
+            if (i + 1) == self.line_no:
+                buf += f"\n{'{:3}'.format(i + 1)} > {line}"
+            elif (i + 1) in range(start, end):
+                buf += f"\n{'{:3}'.format(i + 1)} | {line}"
+
         return buf
 
     def __repr__(self):
-        return f"Location(file={self.file.__repr__()}, line_no={self.line_no.__repr__()}, source_line={repr(self.source_line)})"
+        return f"Location(file={self.file.__repr__()}, line_no={self.line_no.__repr__()}, line_span={self.line_span})"
 
     def __eq__(self, other):
         if not isinstance(other, Location):
@@ -39,13 +59,13 @@ class Location:
             return Location(
                 file=inspect.getfile(obj),
                 line_no=inspect.getsourcelines(obj)[1],
-                source_line="".join(inspect.getsourcelines(obj)[0]),
+                line_span=len(inspect.getsourcelines(obj)[0]),
             )
         except Exception:
             return Location(
                 file=inspect.getfile(obj),
                 line_no=1,
-                source_line=repr(obj)
+                line_span=1,
             )
 
     @staticmethod
@@ -55,37 +75,35 @@ class Location:
                 return Location(
                     file=stack.filename,
                     line_no=stack.lineno,
-                    source_line=stack.code_context[0]
+                    line_span=1
                 )
             except Exception:
                 return Location(
                     file=stack.filename,
                     line_no=stack.lineno,
-                    source_line=None
+                    line_span=1
                 )
         else:  # assume sys._getframe(...)
             try:
-                source_line = inspect.findsource(stack.f_code)[0][stack.f_lineno - 1]
                 return Location(
                     file=stack.f_code.co_filename,
                     line_no=stack.f_lineno,
-                    source_line=source_line
+                    line_span=1
                 )
             except Exception:
                 return Location(
                     file=stack.f_code.co_filename,
                     line_no=stack.f_lineno,
-                    source_line=None
+                    line_span=1
                 )
 
     def mark(self, reti_loc):
         file, line = reti_loc
-        lines = self.source_line.splitlines()
-        if self.file == file and line in range(self.line_no, self.line_no + len(lines)):
+        if self.file == file and line in range(self.line_no, self.line_no + self.line_span):
             return Location(
                 file=file,
                 line_no=line,
-                source_line=lines[line - self.line_no]
+                line_span=1
             )
         else:
             return self

--- a/python/deps/untypy/untypy/impl/generator.py
+++ b/python/deps/untypy/untypy/impl/generator.py
@@ -106,7 +106,7 @@ class TypedGeneratorYieldReturnContext(CompoundTypeExecutionContext):
                 return Location(
                     file=inspect.getfile(self.generator.gi_frame),
                     line_no=inspect.getsourcelines(self.generator.gi_frame)[1],
-                    source_line="\n".join(inspect.getsourcelines(self.generator.gi_frame)[0]),
+                    line_span=len(inspect.getsourcelines(self.generator.gi_frame)[0]),
                 )
         except OSError:  # this call does not work all the time
             pass

--- a/python/deps/untypy/untypy/impl/iterator.py
+++ b/python/deps/untypy/untypy/impl/iterator.py
@@ -71,7 +71,7 @@ class TypedIteratorExecutionContext(CompoundTypeExecutionContext):
                 return Location(
                     file=inspect.getfile(self.iter.gi_frame),
                     line_no=inspect.getsourcelines(self.iter.gi_frame)[1],
-                    source_line="\n".join(inspect.getsourcelines(self.iter.gi_frame)[0]),
+                    line_span=len(inspect.getsourcelines(self.iter.gi_frame)[0]),
                 )
         except OSError:  # this call does not work all the time
             pass

--- a/python/deps/untypy/untypy/impl/protocol.py
+++ b/python/deps/untypy/untypy/impl/protocol.py
@@ -38,7 +38,7 @@ def _find_bound_typevars(clas: type) -> (type, Dict[TypeVar, Any]):
                                    [Location(
                                        file=inspect.getfile(clas),
                                        line_no=inspect.getsourcelines(clas)[1],
-                                       source_line="".join(inspect.getsourcelines(clas)[0]))])
+                                       line_span=len(inspect.getsourcelines(clas)[0]))])
     return (clas.__origin__, dict(zip(keys, values)))
 
 

--- a/python/deps/untypy/untypy/interfaces.py
+++ b/python/deps/untypy/untypy/interfaces.py
@@ -96,7 +96,7 @@ class WrappedFunction:
             return Location(
                 file=inspect.getfile(fn),
                 line_no=inspect.getsourcelines(fn)[1],
-                source_line="".join(inspect.getsourcelines(fn)[0]),
+                line_span=len(inspect.getsourcelines(fn)[0]),
             )
         except:  # Failes on builtins
             return None

--- a/python/deps/untypy/untypy/patching/__init__.py
+++ b/python/deps/untypy/untypy/patching/__init__.py
@@ -28,7 +28,7 @@ def patch_class(clas: type, cfg: Config):
             declared_location=Location(
                 file=inspect.getfile(clas),
                 line_no=inspect.getsourcelines(clas)[1],
-                source_line="".join(inspect.getsourcelines(clas)[0]),
+                line_span=len(inspect.getsourcelines(clas)[0]),
             ), checkedpkgprefixes=cfg.checkedprefixes)
     except (TypeError, OSError) as e:  # Built in types
         ctx = DefaultCreationContext(
@@ -36,7 +36,7 @@ def patch_class(clas: type, cfg: Config):
             declared_location=Location(
                 file="<not found>",
                 line_no=0,
-                source_line="<not found>",
+                line_span=1
             ), checkedpkgprefixes=cfg.checkedprefixes)
 
     setattr(clas, '__patched', True)

--- a/python/deps/untypy/untypy/patching/ast_transformer.py
+++ b/python/deps/untypy/untypy/patching/ast_transformer.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Any
 
 
 class UntypyAstTransformer(ast.NodeTransformer):

--- a/python/deps/untypy/untypy/patching/import_hook.py
+++ b/python/deps/untypy/untypy/patching/import_hook.py
@@ -6,7 +6,7 @@ from importlib.machinery import SourceFileLoader
 from importlib.util import decode_source
 
 
-def install_import_hook(should_patch_predicate: Callable[[str], bool],
+def install_import_hook(should_patch_predicate: Callable[[str, str], bool],
                         transformer: Callable[[str], ast.NodeTransformer]):
     import sys
 
@@ -20,7 +20,7 @@ def install_import_hook(should_patch_predicate: Callable[[str], bool],
 
 class UntypyFinder(MetaPathFinder):
 
-    def __init__(self, inner_finder: MetaPathFinder, should_patch_predicate: Callable[[str], bool],
+    def __init__(self, inner_finder: MetaPathFinder, should_patch_predicate: Callable[[str, str], bool],
                  transformer: Callable[[str], ast.NodeTransformer]):
         self.inner_finder = inner_finder
         self.should_patch_predicate = should_patch_predicate
@@ -41,7 +41,7 @@ class UntypyFinder(MetaPathFinder):
 
 class UntypyLoader(SourceFileLoader):
 
-    def __init__(self, fullname, path, transformer: Callable[[str], ast.NodeTransformer]):
+    def __init__(self, fullname, path, transformer: Callable[[str, str], ast.NodeTransformer]):
         super().__init__(fullname, path)
         self.transformer = transformer
 
@@ -49,7 +49,7 @@ class UntypyLoader(SourceFileLoader):
         source = decode_source(data)
         tree = compile(source, path, 'exec', ast.PyCF_ONLY_AST,
                        dont_inherit=True, optimize=_optimize)
-        self.transformer(self.name.split('.')).visit(tree)
+        self.transformer(self.name.split('.'), self.path).visit(tree)
         ast.fix_missing_locations(tree)
         return compile(tree, path, 'exec', dont_inherit=True, optimize=_optimize)
 

--- a/python/deps/untypy/untypy/util/__init__.py
+++ b/python/deps/untypy/untypy/util/__init__.py
@@ -5,6 +5,7 @@ from typing import Optional, Union, List
 from untypy.display import IndicatorStr
 from untypy.error import UntypyTypeError, Frame, Location
 from untypy.interfaces import ExecutionContext, TypeChecker, WrappedFunction
+from untypy.util.return_traces import get_last_return
 
 
 class ReplaceTypeExecutionContext(ExecutionContext):
@@ -104,6 +105,7 @@ class ReturnExecutionContext(ExecutionContext):
     fn: WrappedFunction
 
     def __init__(self, fn: WrappedFunction):
+        self.reti_loc = get_last_return()
         self.fn = fn
 
     def wrap(self, err: UntypyTypeError) -> UntypyTypeError:
@@ -123,11 +125,15 @@ class ReturnExecutionContext(ExecutionContext):
             return_id = IndicatorStr("???")
 
         declared = WrappedFunction.find_location(self.fn)
+        responsable = declared
+        if responsable is not None:
+            responsable = responsable.mark(self.reti_loc)
+
         return err.with_frame(Frame(
             return_id.ty,
             return_id.indicator,
             declared=declared,
-            responsable=declared,
+            responsable=responsable,
         ))
 
 

--- a/python/deps/untypy/untypy/util/__init__.py
+++ b/python/deps/untypy/untypy/util/__init__.py
@@ -127,7 +127,7 @@ class ReturnExecutionContext(ExecutionContext):
         declared = WrappedFunction.find_location(self.fn)
         responsable = declared
         if responsable is not None:
-            responsable = responsable.mark(self.reti_loc)
+            responsable = responsable.narrow_in_span(self.reti_loc)
 
         return err.with_frame(Frame(
             return_id.ty,

--- a/python/deps/untypy/untypy/util/return_traces.py
+++ b/python/deps/untypy/untypy/util/return_traces.py
@@ -30,8 +30,9 @@ def get_last_return() -> (str, int):
 
 class ReturnTracesTransformer(ast.NodeTransformer):
 
-    def __init__(self, registry: Callable[[ast.Return], int]):
-        self.registry = registry
+    def __init__(self, file: str, manager = GlobalReturnTraceManager):
+        self.file = file
+        self.manager = manager
 
     def generic_visit(self, node) -> Any:
         # See https://docs.python.org/3/library/ast.html
@@ -57,7 +58,7 @@ class ReturnTracesTransformer(ast.NodeTransformer):
             for index, reti in inserts:
                 n = ast.Expr(value=ast.Call(
                     func=ast.Attribute(value=ast.Name(id='untypy', ctx=ast.Load()), attr='_before_return', ctx=ast.Load()),
-                    args=[ast.Constant(value=self.registry(reti))],
+                    args=[ast.Constant(value=self.manager.next_id(reti, self.file))],
                     keywords=[])
                 )
                 statements.insert(index, n)

--- a/python/deps/untypy/untypy/util/return_traces.py
+++ b/python/deps/untypy/untypy/util/return_traces.py
@@ -1,0 +1,66 @@
+import ast
+from typing import *
+
+
+class ReturnTraceManager:
+    def __init__(self):
+        self.lst = []
+
+    def next_id(self, reti : ast.Return, file: str) -> int:
+        i = len(self.lst)
+        self.lst.append((file, reti.lineno))
+        return i
+
+    def get(self, idx : int) -> (str, int):
+        return self.lst[idx]
+
+GlobalReturnTraceManager = ReturnTraceManager()
+reti_loc: int = -1
+
+def before_return(idx : int):
+    global reti_loc
+    reti_loc = idx
+
+def get_last_return() -> (str, int):
+    global reti_loc
+    if reti_loc < 0:
+        return ("<nothing>", 0) # this will never match any real location
+    return GlobalReturnTraceManager.get(reti_loc)
+
+
+class ReturnTracesTransformer(ast.NodeTransformer):
+
+    def __init__(self, registry: Callable[[ast.Return], int]):
+        self.registry = registry
+
+    def generic_visit(self, node) -> Any:
+        # See https://docs.python.org/3/library/ast.html
+        stmt_types = ["body", "orelse", "finalbody"]
+
+        for stmt_type in stmt_types:
+            if not hasattr(node, stmt_type):
+                continue
+            statements : list = getattr(node, stmt_type)
+
+            if not isinstance(statements, Iterable):
+                # skip lambda expressions
+                continue
+
+            inserts = []
+            for i,s in enumerate(statements):
+                if type(s) is ast.Return:
+                    inserts.append((i, s))
+
+            # start at end so the early indexes still fit
+            inserts.reverse()
+
+            for index, reti in inserts:
+                n = ast.Expr(value=ast.Call(
+                    func=ast.Attribute(value=ast.Name(id='untypy', ctx=ast.Load()), attr='_before_return', ctx=ast.Load()),
+                    args=[ast.Constant(value=self.registry(reti))],
+                    keywords=[])
+                )
+                statements.insert(index, n)
+
+        super(ast.NodeTransformer, self).generic_visit(node)
+

--- a/python/deps/untypy/untypy/util/return_traces.py
+++ b/python/deps/untypy/untypy/util/return_traces.py
@@ -3,6 +3,9 @@ from typing import *
 
 
 class ReturnTraceManager:
+    """
+    Stores file & line_no to every return idx
+    """
     def __init__(self):
         self.lst = []
 
@@ -17,20 +20,25 @@ class ReturnTraceManager:
 GlobalReturnTraceManager = ReturnTraceManager()
 reti_loc: int = -1
 
+
 def before_return(idx : int):
     global reti_loc
     reti_loc = idx
+
 
 def get_last_return() -> (str, int):
     global reti_loc
     if reti_loc < 0:
         return ("<nothing>", 0) # this will never match any real location
+
+    # Note: this location is only used if it is in the span of the located function.
+    # See ReturnExecutionContext
     return GlobalReturnTraceManager.get(reti_loc)
 
 
 class ReturnTracesTransformer(ast.NodeTransformer):
 
-    def __init__(self, file: str, manager = GlobalReturnTraceManager):
+    def __init__(self, file: str, manager=GlobalReturnTraceManager):
         self.file = file
         self.manager = manager
 

--- a/python/deps/untypy/untypy/util/tranformer_combinator.py
+++ b/python/deps/untypy/untypy/util/tranformer_combinator.py
@@ -1,0 +1,11 @@
+import ast
+
+
+class TransformerCombinator(ast.NodeTransformer):
+
+    def __init__(self, *inner: ast.NodeTransformer):
+        self.inner = inner
+
+    def visit(self, node):
+        for inner in self.inner:
+            inner.visit(node)

--- a/python/fileTests
+++ b/python/fileTests
@@ -137,7 +137,7 @@ checkWithOutputAux yes 0 test-data/testForwardRef1.py
 checkWithOutputAux yes 1 test-data/testForwardRef2.py
 checkWithOutputAux yes 0 test-data/testForwardRef3.py
 checkWithOutputAux yes 1 test-data/testForwardRef4.py
-# checkWithOutputAux yes 1 test-data/testTypesReturn.py  See #15
+checkWithOutputAux yes 1 test-data/testTypesReturn.py
 checkWithOutputAux yes 1 test-data/testTypesSequence1.py
 checkWithOutputAux yes 1 test-data/testTypesSequence2.py
 checkWithOutputAux yes 1 test-data/testTypesTuple1.py

--- a/python/integration-tests/testIntegration.py
+++ b/python/integration-tests/testIntegration.py
@@ -59,12 +59,14 @@ expected: value of type int
 context: Person(name: str, age: int) -> Self
                                 ^^^
 declared at: test-data/typeRecords.py:3
-  3 | @record
+  1 | from wypp import *
+  2 | 
+  3 > @record
   4 | class Person:
   5 |     name: str
-  6 |     age: int
 
-caused by: <console>:1"""
+caused by: <console>:1
+  1 | <source code not found>"""
         self.assertEqual(expected, '\n'.join(out))
 
     def test_recordFail2(self):
@@ -153,10 +155,11 @@ expected: value of type int
 context: inc(x: int) -> int
                 ^^^
 declared at: test-data/testTypesInteractive.py:1
-  1 | def inc(x: int) -> int:
+  1 > def inc(x: int) -> int:
   2 |     return x + 1
 
-caused by: <console>:1"""
+caused by: <console>:1
+  1 | <source code not found>"""
         self.assertEqual(expected, out)
 
     def test_types3(self):

--- a/python/src/runner.py
+++ b/python/src/runner.py
@@ -281,7 +281,7 @@ def runCode(fileToRun, globals, args, useUntypy=True):
                 verbose(f"transforming {fileToRun} for typechecking")
                 tree = compile(codeTxt, fileToRun, 'exec', flags=(flags | ast.PyCF_ONLY_AST),
                                dont_inherit=True, optimize=-1)
-                untypy.transform_tree(tree)
+                untypy.transform_tree(tree, os.path.abspath(fileToRun))
                 verbose(f'done with transformation of {fileToRun}')
                 code = tree
             else:

--- a/python/src/runner.py
+++ b/python/src/runner.py
@@ -481,10 +481,12 @@ class TypecheckedInteractiveConsole(code.InteractiveConsole):
         if code is None:
             return True
         try:
-            ast = untypy.just_transform("\n".join(self.buffer), filename, symbol)
+            import ast
+            tree = compile("\n".join(self.buffer), filename, symbol, flags=ast.PyCF_ONLY_AST, dont_inherit=True, optimize=-1)
+            tree = untypy.transform_tree(tree, filename)
             code = compile(ast, filename, symbol)
         except Exception as e:
-            if e.text == "":
+            if hasattr(e, "text") and e.text == "":
                 pass
             else:
                 traceback.print_tb(e.__traceback__)

--- a/python/src/runner.py
+++ b/python/src/runner.py
@@ -269,7 +269,7 @@ class RunSetup:
 
 def runCode(fileToRun, globals, args, useUntypy=True):
     localDir = os.path.dirname(fileToRun)
-    fileToRun = os.path.abspath(fileToRun)
+    
     with RunSetup(localDir):
         with open(fileToRun) as f:
             flags = 0 | anns.compiler_flag

--- a/python/src/runner.py
+++ b/python/src/runner.py
@@ -269,6 +269,7 @@ class RunSetup:
 
 def runCode(fileToRun, globals, args, useUntypy=True):
     localDir = os.path.dirname(fileToRun)
+    fileToRun = os.path.abspath(fileToRun)
     with RunSetup(localDir):
         with open(fileToRun) as f:
             flags = 0 | anns.compiler_flag
@@ -281,7 +282,7 @@ def runCode(fileToRun, globals, args, useUntypy=True):
                 verbose(f"transforming {fileToRun} for typechecking")
                 tree = compile(codeTxt, fileToRun, 'exec', flags=(flags | ast.PyCF_ONLY_AST),
                                dont_inherit=True, optimize=-1)
-                untypy.transform_tree(tree, os.path.abspath(fileToRun))
+                untypy.transform_tree(tree, fileToRun)
                 verbose(f'done with transformation of {fileToRun}')
                 code = tree
             else:

--- a/python/src/runner.py
+++ b/python/src/runner.py
@@ -269,7 +269,6 @@ class RunSetup:
 
 def runCode(fileToRun, globals, args, useUntypy=True):
     localDir = os.path.dirname(fileToRun)
-    fileToRun = os.path.abspath(fileToRun)
     with RunSetup(localDir):
         with open(fileToRun) as f:
             flags = 0 | anns.compiler_flag
@@ -282,7 +281,7 @@ def runCode(fileToRun, globals, args, useUntypy=True):
                 verbose(f"transforming {fileToRun} for typechecking")
                 tree = compile(codeTxt, fileToRun, 'exec', flags=(flags | ast.PyCF_ONLY_AST),
                                dont_inherit=True, optimize=-1)
-                untypy.transform_tree(tree, fileToRun)
+                untypy.transform_tree(tree, os.path.abspath(fileToRun))
                 verbose(f'done with transformation of {fileToRun}')
                 code = tree
             else:

--- a/python/src/runner.py
+++ b/python/src/runner.py
@@ -483,10 +483,10 @@ class TypecheckedInteractiveConsole(code.InteractiveConsole):
         try:
             import ast
             tree = compile("\n".join(self.buffer), filename, symbol, flags=ast.PyCF_ONLY_AST, dont_inherit=True, optimize=-1)
-            tree = untypy.transform_tree(tree, filename)
-            code = compile(ast, filename, symbol)
+            untypy.transform_tree(tree, filename)
+            code = compile(tree, filename, symbol)
         except Exception as e:
-            if hasattr(e, "text") and e.text == "":
+            if hasattr(e, 'text') and e.text == "":
                 pass
             else:
                 traceback.print_tb(e.__traceback__)

--- a/python/test-data/declared-at-missing.err
+++ b/python/test-data/declared-at-missing.err
@@ -5,11 +5,13 @@ expected: value of type CourseM
 context: Semester(degreeProgram: str, semester: str, courses: tuple[CourseM, ...]) -> Self
                                                                     ^^^^^^^
 declared at: test-data/declared-at-missing.py:15
- 15 | @record
+ 13 |     students: tuple[str, ...]
+ 14 | 
+ 15 > @record
  16 | class Semester:
  17 |     degreeProgram: str
- 18 |     semester: str
- 19 |     courses: tuple[CourseM, ...]
 
 caused by: test-data/declared-at-missing.py:22
- 22 | semester1_2020 = Semester('AKI', '1. Semester 2020/21', (prog1, ))
+ 20 | 
+ 21 | prog1 = Course('Programmierung 1', 'Wehr', ())
+ 22 > semester1_2020 = Semester('AKI', '1. Semester 2020/21', (prog1, ))

--- a/python/test-data/testForwardRef2.err
+++ b/python/test-data/testForwardRef2.err
@@ -1,7 +1,8 @@
 untypy.error.UntypyNameError: name 'Foo' is not defined.
 Type annotation of function 'Test.__init__' could not be resolved.
 declared at: test-data/testForwardRef2.py:2
-  2 |     def __init__(self, foo: 'Foo'):
+  1 | class Test:
+  2 >     def __init__(self, foo: 'Foo'):
   3 |         pass
   4 |     def __repr__(self):
   5 |         return 'Test'

--- a/python/test-data/testForwardRef2.err
+++ b/python/test-data/testForwardRef2.err
@@ -2,5 +2,8 @@ untypy.error.UntypyNameError: The name 'Foo' is not defined.
 Type annotation of function 'Test.__init__' is not resoveable.
 Did you forget importing this type?
 test-data/testForwardRef2.py:2
-  2 |     def __init__(self, foo: 'Foo'):
+  1 | class Test:
+  2 >     def __init__(self, foo: 'Foo'):
   3 |         pass
+  4 |     def __repr__(self):
+  5 |         return 'Test'

--- a/python/test-data/testForwardRef4.err
+++ b/python/test-data/testForwardRef4.err
@@ -1,16 +1,8 @@
-<<<<<<< HEAD
-untypy.error.UntypyNameError: The name 'FooX' is not defined.
-Type annotation of Class 'Test' is not resoveable.
-Did you forget importing this type?
-test-data/testForwardRef4.py:3
-  1 | from wypp import *
-  2 | 
-  3 > @record
-=======
 untypy.error.UntypyNameError: name 'FooX' is not defined.
 Type annotation of class 'Test' could not be resolved.
 declared at: test-data/testForwardRef4.py:3
-  3 | @record
->>>>>>> master
+  1 | from wypp import *
+  2 | 
+  3 > @record
   4 | class Test:
   5 |     foo: 'FooX'

--- a/python/test-data/testForwardRef4.err
+++ b/python/test-data/testForwardRef4.err
@@ -2,6 +2,8 @@ untypy.error.UntypyNameError: The name 'FooX' is not defined.
 Type annotation of Class 'Test' is not resoveable.
 Did you forget importing this type?
 test-data/testForwardRef4.py:3
-  3 | @record
+  1 | from wypp import *
+  2 | 
+  3 > @record
   4 | class Test:
   5 |     foo: 'FooX'

--- a/python/test-data/testTypes1.err
+++ b/python/test-data/testTypes1.err
@@ -5,8 +5,12 @@ expected: value of type int
 context: inc(x: int) -> int
                 ^^^
 declared at: test-data/testTypes1.py:1
-  1 | def inc(x: int) -> int:
+  1 > def inc(x: int) -> int:
   2 |     return x + 1
+  3 | 
+  4 | inc("1")
 
 caused by: test-data/testTypes1.py:4
-  4 | inc("1")
+  2 |     return x + 1
+  3 | 
+  4 > inc("1")

--- a/python/test-data/testTypes2.err
+++ b/python/test-data/testTypes2.err
@@ -5,8 +5,12 @@ expected: value of type int
 context: inc(x: int) -> int
                 ^^^
 declared at: test-data/testTypes2.py:1
-  1 | def inc(x: int) -> int:
+  1 > def inc(x: int) -> int:
   2 |     return x
+  3 | 
+  4 | inc("1")
 
 caused by: test-data/testTypes2.py:4
-  4 | inc("1")
+  2 |     return x
+  3 | 
+  4 > inc("1")

--- a/python/test-data/testTypesCollections1.err
+++ b/python/test-data/testTypesCollections1.err
@@ -5,8 +5,15 @@ expected: value of type int
 context: list[int]
               ^^^
 declared at: test-data/testTypesCollections1.py:3
-  3 | def appendSomething(l: list[int]) -> None:
+  1 | from wypp import *
+  2 | 
+  3 > def appendSomething(l: list[int]) -> None:
   4 |     l.append("foo")
+  5 |
 
 caused by: test-data/testTypesCollections1.py:4
-  4 |     l.append("foo")
+  2 | 
+  3 | def appendSomething(l: list[int]) -> None:
+  4 >     l.append("foo")
+  5 | 
+  6 | l = [1,2,3]

--- a/python/test-data/testTypesCollections2.err
+++ b/python/test-data/testTypesCollections2.err
@@ -5,11 +5,13 @@ expected: value of type str
 context: foo(l: list[Callable[[], str]]) -> list[str]
                                   ^^^
 declared at: test-data/testTypesCollections2.py:3
-  3 | def foo(l: list[Callable[[], str]]) -> list[str]:
+  1 | from wypp import *
+  2 | 
+  3 > def foo(l: list[Callable[[], str]]) -> list[str]:
   4 |     res = []
   5 |     for f in l:
-  6 |         res.append(f())
-  7 |     return res
 
 caused by: test-data/testTypesCollections2.py:10
- 10 | foo([lambda: "1", lambda: 42]) # error because the 2nd functions returns an int
+  8 | 
+  9 | print(foo([lambda: "1", lambda: "2"]))
+ 10 > foo([lambda: "1", lambda: 42]) # error because the 2nd functions returns an int

--- a/python/test-data/testTypesCollections4.err
+++ b/python/test-data/testTypesCollections4.err
@@ -5,16 +5,25 @@ expected: value of type str
 context: foo(l: list[Callable[[], str]]) -> list[str]
                                   ^^^
 declared at: test-data/testTypesCollections4.py:4
-  4 |     l.append(lambda: 42) # error
-declared at: test-data/testTypesCollections4.py:3
+  2 | 
   3 | def foo(l: list[Callable[[], str]]) -> list[str]:
-  4 |     l.append(lambda: 42) # error
+  4 >     l.append(lambda: 42) # error
   5 |     res = []
   6 |     for f in l:
-  7 |         res.append(f())
-    | ...
+declared at: test-data/testTypesCollections4.py:3
+  1 | from wypp import *
+  2 | 
+  3 > def foo(l: list[Callable[[], str]]) -> list[str]:
+  4 |     l.append(lambda: 42) # error
+  5 |     res = []
 
 caused by: test-data/testTypesCollections4.py:4
-  4 |     l.append(lambda: 42) # error
+  2 | 
+  3 | def foo(l: list[Callable[[], str]]) -> list[str]:
+  4 >     l.append(lambda: 42) # error
+  5 |     res = []
+  6 |     for f in l:
 caused by: test-data/testTypesCollections4.py:10
- 10 | foo([])
+  8 |     return res
+  9 | 
+ 10 > foo([])

--- a/python/test-data/testTypesHigherOrderFuns.err
+++ b/python/test-data/testTypesHigherOrderFuns.err
@@ -5,11 +5,13 @@ expected: value of type int
 context: map(container: Iterable[str], fun: Callable[[str], int]) -> list[int]
                                                             ^^^
 declared at: test-data/testTypesHigherOrderFuns.py:3
-  3 | def map(container: Iterable[str], fun: Callable[[str], int]) -> list[int]:
+  1 | from wypp import *
+  2 | 
+  3 > def map(container: Iterable[str], fun: Callable[[str], int]) -> list[int]:
   4 |     res = []
   5 |     for x in container:
-  6 |         res.append(fun(x))
-  7 |     return res
 
 caused by: test-data/testTypesHigherOrderFuns.py:10
- 10 | map(["hello", "1"], lambda x: x)
+  8 | 
+  9 | print(map(["hello", "1"], len))
+ 10 > map(["hello", "1"], lambda x: x)

--- a/python/test-data/testTypesProtos1.err
+++ b/python/test-data/testTypesProtos1.err
@@ -7,11 +7,16 @@ expected: value of type Animal
 context: doSomething(a: Animal) -> None
                         ^^^^^^
 declared at: test-data/testTypesProtos1.py:18
- 18 | def doSomething(a: Animal) -> None:
+ 16 |         return "<Dog object>"
+ 17 | 
+ 18 > def doSomething(a: Animal) -> None:
  19 |     print(a.makeSound(3.14))
+ 20 |
 
 caused by: test-data/testTypesProtos1.py:21
- 21 | doSomething(Dog())
+ 19 |     print(a.makeSound(3.14))
+ 20 | 
+ 21 > doSomething(Dog())
 
 The argument 'loadness' of method 'makeSound' violates the protocol 'Animal'.
 The annotation 'int' is incompatible with the protocol's annotation 'float'
@@ -23,12 +28,21 @@ expected: value of type int
 context: makeSound(self: Self, loadness: int) -> str
                                          ^^^
 declared at: test-data/testTypesProtos1.py:13
- 13 |     def makeSound(self, loadness: int) -> str:
+ 11 | class Dog:
+ 12 |     # incorrect implementation of the Animal protocol
+ 13 >     def makeSound(self, loadness: int) -> str:
  14 |         return f"{loadness} wuffs"
+ 15 |     def __repr__(self):
 declared at: test-data/testTypesProtos1.py:8
-  8 |     def makeSound(self, loadness: float) -> str:
+  6 | class Animal(Protocol):
+  7 |     @abc.abstractmethod
+  8 >     def makeSound(self, loadness: float) -> str:
   9 |         pass
+ 10 |
 
 caused by: test-data/testTypesProtos1.py:13
- 13 |     def makeSound(self, loadness: int) -> str:
+ 11 | class Dog:
+ 12 |     # incorrect implementation of the Animal protocol
+ 13 >     def makeSound(self, loadness: int) -> str:
  14 |         return f"{loadness} wuffs"
+ 15 |     def __repr__(self):

--- a/python/test-data/testTypesProtos3.err
+++ b/python/test-data/testTypesProtos3.err
@@ -7,8 +7,13 @@ expected: value of type Animal
 context: doSomething(a: Animal) -> None
                         ^^^^^^
 declared at: test-data/testTypesProtos3.py:16
- 16 | def doSomething(a: Animal) -> None:
+ 14 |         return f"{loadness} wuffs"
+ 15 | 
+ 16 > def doSomething(a: Animal) -> None:
  17 |     print(a.makeSound(3.14))
+ 18 |
 
 caused by: test-data/testTypesProtos3.py:19
- 19 | doSomething(Dog())
+ 17 |     print(a.makeSound(3.14))
+ 18 | 
+ 19 > doSomething(Dog())

--- a/python/test-data/testTypesReturn.err
+++ b/python/test-data/testTypesReturn.err
@@ -1,0 +1,19 @@
+untypy.error.UntypyTypeError
+given:    'you stupid'
+expected: value of type int
+
+context: foo(flag: bool) -> int
+                            ^^^
+declared at: test-data/testTypesReturn.py:1
+  1 > def foo(flag: bool) -> int:
+  2 |     print('Hello World')
+  3 |     if flag:
+  4 |         return 1
+  5 |     else:
+
+caused by: test-data/testTypesReturn.py:6
+  4 |         return 1
+  5 |     else:
+  6 >         return 'you stupid'
+  7 | 
+  8 | foo(False)

--- a/python/test-data/testTypesReturn.out
+++ b/python/test-data/testTypesReturn.out
@@ -1,0 +1,1 @@
+Hello World

--- a/python/test-data/testTypesSequence1.err
+++ b/python/test-data/testTypesSequence1.err
@@ -5,9 +5,13 @@ expected: value of type Sequence
 context: foo(seq: Sequence) -> None
                   ^^^^^^^^
 declared at: test-data/testTypesSequence1.py:3
-  3 | def foo(seq: Sequence) -> None:
+  1 | from wypp import *
+  2 | 
+  3 > def foo(seq: Sequence) -> None:
   4 |     print(seq)
   5 |     pass
 
 caused by: test-data/testTypesSequence1.py:10
- 10 | foo(1) # should fail
+  8 | foo( ("bar", "baz") )
+  9 | foo("Hello!")
+ 10 > foo(1) # should fail

--- a/python/test-data/testTypesSequence2.err
+++ b/python/test-data/testTypesSequence2.err
@@ -5,9 +5,13 @@ expected: value of type Sequence[int]
 context: foo(seq: Sequence[int]) -> None
                   ^^^^^^^^^^^^^
 declared at: test-data/testTypesSequence2.py:3
-  3 | def foo(seq: Sequence[int]) -> None:
+  1 | from wypp import *
+  2 | 
+  3 > def foo(seq: Sequence[int]) -> None:
   4 |     print(seq)
   5 |     pass
 
 caused by: test-data/testTypesSequence2.py:9
-  9 | foo("Hello!") # should fail
+  7 | foo([1,2,3])
+  8 | foo( (4,5)  )
+  9 > foo("Hello!") # should fail

--- a/python/test-data/testTypesTuple1.err
+++ b/python/test-data/testTypesTuple1.err
@@ -5,8 +5,13 @@ expected: value of type tuple[int, ...]
 context: foo(l: tuple[int, ...]) -> int
                 ^^^^^^^^^^^^^^^
 declared at: test-data/testTypesTuple1.py:1
-  1 | def foo(l: tuple[int, ...]) -> int:
+  1 > def foo(l: tuple[int, ...]) -> int:
   2 |     return len(l)
+  3 | 
+  4 | print(foo((1,2,3)))
+  5 | foo(1)
 
 caused by: test-data/testTypesTuple1.py:5
-  5 | foo(1)
+  3 | 
+  4 | print(foo((1,2,3)))
+  5 > foo(1)


### PR DESCRIPTION
closes #15

Extra function calls are inserted in the AST. If a "return"-location is searched, and the last return was triggered inside of the function that causes the violation, the location of the return is used.

Also the formatting of location has been changed.  Now a Location is a "single line". When printing the 2 surrounding lines are also shown. 

```python
def foo(flag: bool) -> int:
    print('Hello World')
    if flag:
        return 1
    else:
        return 'you stupid'

foo(False)
```
outputs
```
declared at: test-data/testTypesReturn.py:1
  1 > def foo(flag: bool) -> int:
  2 |     print('Hello World')
  3 |     if flag:
  4 |         return 1
  5 |     else:

caused by: test-data/testTypesReturn.py:6
  4 |         return 1
  5 |     else:
  6 >         return 'you stupid'
  7 | 
  8 | foo(False)
```
