### PR TITLE
Feature/8 argument missmatch

### DIFF
--- a/python/deps/untypy/untypy/util/__init__.py
+++ b/python/deps/untypy/untypy/util/__init__.py
@@ -2,7 +2,7 @@ import inspect
 import types
 from typing import Optional, Union, List
 
-from untypy.display import IndicatorStr
+from untypy.util.display import IndicatorStr
 from untypy.error import UntypyTypeError, Frame, Location
 from untypy.interfaces import ExecutionContext, TypeChecker, WrappedFunction
 from untypy.util.return_traces import get_last_return

--- a/python/deps/untypy/untypy/util/display.py
+++ b/python/deps/untypy/untypy/util/display.py
@@ -1,3 +1,6 @@
+import inspect
+
+
 class IndicatorStr:
     ty: str
     indicator: str
@@ -17,3 +20,13 @@ class IndicatorStr:
             self.ty.join(map(lambda s: s.ty, lst)),
             self.indicator.join(map(lambda s: s.indicator, lst)),
         )
+
+
+def format_argument_values(args, kwargs):
+    allargs = []
+    for a in args:
+        allargs.append(a.__repr__())
+    for k,v in kwargs.items():
+        allargs.append(k + "=" + v.__repr__())
+
+    return "(" + ", ".join(allargs) + ")"

--- a/python/fileTests
+++ b/python/fileTests
@@ -126,7 +126,7 @@ checkWithOutputAux yes 1 test-data/testTypesCollections2.py
 # checkWithOutputAux yes 1 test-data/testTypesCollections3.py  See #5
 checkWithOutputAux yes 1 test-data/testTypesCollections4.py
 checkWithOutputAux yes 1 test-data/testTypesProtos1.py
-# checkWithOutputAux yes 1 test-data/testTypesProtos2.py  See #8
+checkWithOutputAux yes 1 test-data/testTypesProtos2.py
 checkWithOutputAux yes 1 test-data/testTypesProtos3.py
 # checkWithOutputAux yes 1 test-data/testTypesProtos4.py  See #9
 # checkWithOutputAux yes 1 test-data/testTypesSubclassing1.py  See #10

--- a/python/test-data/testTypesProtos2.err
+++ b/python/test-data/testTypesProtos2.err
@@ -1,0 +1,22 @@
+untypy.error.UntypyTypeError
+Arguments do not match.
+Hint: 'self'-parameter was omitted in declaration.
+
+given:    '(<__wypp__.Dog object at 0x7fca96d507c0>, 3.14)'
+expected: value of type makeSound(loadness: 'float') -> 'str'
+
+context: makeSound(loadness: float) -> str
+         
+declared at: test-data/testTypesProtos2.py:8
+  6 | class Animal(Protocol):
+  7 |     @abc.abstractmethod
+  8 >     def makeSound(loadness: float) -> str: # self parameter omitted!
+  9 |         pass
+ 10 |
+
+caused by: test-data/testTypesProtos2.py:17
+ 15 | 
+ 16 | def doSomething(a: Animal) -> None:
+ 17 >     print(a.makeSound(3.14))
+ 18 | 
+ 19 | doSomething(Dog())


### PR DESCRIPTION
closes #9 

added message if there is an argument mismatch.

"value of type" does not quite fit for the expected type. 
```
expected: value of type makeSound(loadness: 'float') -> 'str'
```
The "expected"-part of error messages should be rewritten in #5. Probably a tree-like structure fits better.  