### PR TITLE
Feature/19 check more dict fns

### DIFF
--- a/python/deps/untypy/test/impl/test_interface_dict.py
+++ b/python/deps/untypy/test/impl/test_interface_dict.py
@@ -77,7 +77,6 @@ class TestInterfaceDict(unittest.TestCase):
             [1, 2, 3]
         )
 
-    @unittest.skip("this test fails")
     def test_pop(self):
         self.assertEqual(self.good.pop(1), "one")
         self.assertEqual(self.good.pop(4), None)
@@ -180,7 +179,6 @@ class TestInterfaceDict(unittest.TestCase):
         with self.assertRaises(UntypyTypeError):
             list(reversed(self.keyerr))
 
-    @unittest.skip("this test fails")
     def test_getitem(self):
         self.assertEqual(self.good[1], "one")
 

--- a/python/deps/untypy/test/impl/test_interface_dict.py
+++ b/python/deps/untypy/test/impl/test_interface_dict.py
@@ -148,13 +148,16 @@ class TestInterfaceDict(unittest.TestCase):
             # Cannot be in if Key : str.
             "42" in self.good
 
-    @unittest.skip("this test fails")
     def test_delitem(self):
         del self.good[1]
-        del self.good[4]
+
+        with self.assertRaises(KeyError):
+            del self.good[4]
 
         with self.assertRaises(UntypyTypeError):
             del self.good["four"]
+
+        self.assertEqual(self.good, {2: "two", 3: "three"})
 
     def test_iter(self):
         for k in self.good:

--- a/python/deps/untypy/test/impl/test_interface_dict.py
+++ b/python/deps/untypy/test/impl/test_interface_dict.py
@@ -170,7 +170,6 @@ class TestInterfaceDict(unittest.TestCase):
             for k in self.keyerr:
                 pass
 
-
     def test_len(self):
         self.assertEqual(len(self.good), 3)
 

--- a/python/deps/untypy/test/impl/test_interface_dict.py
+++ b/python/deps/untypy/test/impl/test_interface_dict.py
@@ -4,7 +4,7 @@ from untypy.error import UntypyTypeError
 
 class TestInterfaceDict(UntypyTestCase):
     """
-    Test's that the signatures match the implementation.
+    Test's that the signatures matches the implementation.
     """
 
     def setUp(self) -> None:

--- a/python/deps/untypy/test/impl/test_interface_dict.py
+++ b/python/deps/untypy/test/impl/test_interface_dict.py
@@ -140,7 +140,6 @@ class TestInterfaceDict(unittest.TestCase):
         with self.assertRaises(UntypyTypeError):
             list(self.valerr.values())
 
-    @unittest.skip("this test fails")
     def test_contains(self):
         self.assertTrue(1 in self.good)
         self.assertFalse(4 in self.good)

--- a/python/deps/untypy/test/impl/test_interface_dict.py
+++ b/python/deps/untypy/test/impl/test_interface_dict.py
@@ -1,0 +1,202 @@
+import unittest
+
+import untypy
+from untypy.error import UntypyTypeError
+
+
+class TestInterfaceDict(unittest.TestCase):
+    """
+    Test's that the signatures match the implementation.
+    """
+
+    def setUp(self) -> None:
+        ch1 = untypy.checker(lambda: dict[int, str], TestInterfaceDict.setUp)
+
+        # A: No Errors
+        self.good = ch1({
+            1: "one",
+            2: "two",
+            3: "three",
+        })
+
+        # B: Value error on 2
+        self.valerr = ch1({
+            1: "one",
+            2: 2,
+            3: "three",
+        })
+
+        # B: Key error on 2
+        self.keyerr = ch1({
+            1: "one",
+            "two": 2,
+            3: "three",
+        })
+
+    def test_get(self):
+        self.assertEqual(self.good.get(1), "one")
+        self.assertEqual(self.good.get(4), None)
+        self.assertEqual(self.good.get(4, "four"), "four")
+
+        with self.assertRaises(UntypyTypeError):
+            # 42 must be str
+            self.good.get(1, 42)
+
+        with self.assertRaises(UntypyTypeError):
+            # key must be int
+            self.good.get("two")
+
+        with self.assertRaises(UntypyTypeError):
+            # value err
+            self.valerr.get(2)
+
+    def test_items(self):
+        self.assertEqual(
+            list(self.good.items()),
+            [(1, "one"), (2, "two"), (3, "three")]
+        )
+
+        with self.assertRaises(UntypyTypeError):
+            list(self.keyerr.items())
+
+        with self.assertRaises(UntypyTypeError):
+            list(self.valerr.items())
+
+    def test_keys(self):
+        self.assertEqual(
+            list(self.good.keys()),
+            [1, 2, 3]
+        )
+
+        with self.assertRaises(UntypyTypeError):
+            list(self.keyerr.keys())
+
+        # values stay unchecked
+        self.assertEqual(
+            list(self.valerr.keys()),
+            [1, 2, 3]
+        )
+
+    @unittest.skip("this test fails")
+    def test_pop(self):
+        self.assertEqual(self.good.pop(1), "one")
+        self.assertEqual(self.good.pop(4), None)
+        self.assertEqual(self.good.pop(4, "four"), "four")
+
+        with self.assertRaises(UntypyTypeError):
+            self.good.pop("one")
+
+        with self.assertRaises(UntypyTypeError):
+            self.valerr.pop(2)
+
+    def test_popitem(self):
+        self.assertEqual(self.good.popitem(), (3, "three"))
+        self.assertEqual(self.good.popitem(), (2, "two"))
+        self.assertEqual(self.good.popitem(), (1, "one"))
+
+        with self.assertRaises(KeyError):
+            self.good.popitem()
+
+        self.assertEqual(self.keyerr.popitem(), (3, "three"))
+        with self.assertRaises(UntypyTypeError):
+            self.keyerr.popitem()
+
+        self.assertEqual(self.valerr.popitem(), (3, "three"))
+        with self.assertRaises(UntypyTypeError):
+            self.valerr.popitem()
+
+    def test_setdefault(self):
+        self.assertEqual(self.good.setdefault(1, "xxx"), "one")
+
+        with self.assertRaises(UntypyTypeError):
+            # Untypy does not support setdefault w/o default=XXX
+            # https://github.com/skogsbaer/write-your-python-program/issues/19
+            self.good.setdefault(5)
+
+        self.assertEqual(self.good.setdefault(4, "four"), "four")
+        self.assertEqual(self.good.get(4), "four")
+
+        with self.assertRaises(UntypyTypeError):
+            # 42 must be str
+            self.good.setdefault(4, 42)
+
+        with self.assertRaises(UntypyTypeError):
+            self.valerr.setdefault(2)
+
+    def test_values(self):
+        self.assertEqual(
+            list(self.good.values()),
+            ["one", "two", "three"]
+        )
+
+        with self.assertRaises(UntypyTypeError):
+            # This failes also, but I don't know why.
+            # However the keys violate the annotation,
+            # So this is fine.
+            self.assertEqual(
+                list(self.keyerr.values()),
+                ["one", "two", "three"]
+            )
+
+        with self.assertRaises(UntypyTypeError):
+            list(self.valerr.values())
+
+    @unittest.skip("this test fails")
+    def test_contains(self):
+        self.assertTrue(1 in self.good)
+        self.assertFalse(4 in self.good)
+
+        with self.assertRaises(UntypyTypeError):
+            # Cannot be in if Key : str.
+            "42" in self.good
+
+    @unittest.skip("this test fails")
+    def test_delitem(self):
+        del self.good[1]
+        del self.good[4]
+
+        with self.assertRaises(UntypyTypeError):
+            del self.good["four"]
+
+    def test_iter(self):
+        for k in self.good:
+            pass
+
+        for k in self.valerr:
+            pass
+
+        with self.assertRaises(UntypyTypeError):
+            for k in self.keyerr:
+                pass
+
+
+    def test_len(self):
+        self.assertEqual(len(self.good), 3)
+
+    def test_reversed(self):
+        self.assertEqual(list(reversed(self.good)), [3, 2, 1])
+        self.assertEqual(list(reversed(self.valerr)), [3, 2, 1])
+
+        with self.assertRaises(UntypyTypeError):
+            list(reversed(self.keyerr))
+
+    @unittest.skip("this test fails")
+    def test_getitem(self):
+        self.assertEqual(self.good[1], "one")
+
+        with self.assertRaises(UntypyTypeError):
+            self.good["two"]
+
+        with self.assertRaises(UntypyTypeError):
+            self.valerr[2]
+
+    def test_setiem(self):
+        self.good[1] = "not one"
+
+        with self.assertRaises(UntypyTypeError):
+            # key err
+            self.good["key"] = "one"
+
+        with self.assertRaises(UntypyTypeError):
+            # val err
+            self.good[4] = 44

--- a/python/deps/untypy/test/impl/test_interface_dict.py
+++ b/python/deps/untypy/test/impl/test_interface_dict.py
@@ -1,7 +1,18 @@
 import unittest
 
 import untypy
-from untypy.error import UntypyTypeError
+from untypy.error import UntypyTypeError, Location
+
+
+def dummy_caller_2(ch, arg):
+    return ch(arg)
+
+
+# Sets up callstack so that this function is blamed for creation.
+# untypy.checker uses the function that called the function that
+# invokes the checker.
+def dummy_caller(ch, arg):
+    return dummy_caller_2(ch, arg)
 
 
 class TestInterfaceDict(unittest.TestCase):
@@ -10,45 +21,51 @@ class TestInterfaceDict(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        ch1 = untypy.checker(lambda: dict[int, str], TestInterfaceDict.setUp)
+        ch1 = untypy.checker(lambda: dict[int, str], dummy_caller)
 
         # A: No Errors
-        self.good = ch1({
+        self.good = dummy_caller(ch1, {
             1: "one",
             2: "two",
             3: "three",
         })
 
         # B: Value error on 2
-        self.valerr = ch1({
+        self.valerr = dummy_caller(ch1, {
             1: "one",
             2: 2,
             3: "three",
         })
 
         # B: Key error on 2
-        self.keyerr = ch1({
+        self.keyerr = dummy_caller(ch1, {
             1: "one",
             "two": 2,
             3: "three",
         })
+
+    def assertBlame(self, cm, caller):
+        self.assertTrue(cm.exception.last_responsable() in Location.from_code(caller))
 
     def test_get(self):
         self.assertEqual(self.good.get(1), "one")
         self.assertEqual(self.good.get(4), None)
         self.assertEqual(self.good.get(4, "four"), "four")
 
-        with self.assertRaises(UntypyTypeError):
+        with self.assertRaises(UntypyTypeError) as cm:
             # 42 must be str
             self.good.get(1, 42)
+        self.assertBlame(cm, TestInterfaceDict.test_get)
 
-        with self.assertRaises(UntypyTypeError):
+        with self.assertRaises(UntypyTypeError) as cm:
             # key must be int
             self.good.get("two")
+        self.assertBlame(cm, TestInterfaceDict.test_get)
 
-        with self.assertRaises(UntypyTypeError):
+        with self.assertRaises(UntypyTypeError) as cm:
             # value err
             self.valerr.get(2)
+        self.assertBlame(cm, dummy_caller)
 
     def test_items(self):
         self.assertEqual(
@@ -56,10 +73,10 @@ class TestInterfaceDict(unittest.TestCase):
             [(1, "one"), (2, "two"), (3, "three")]
         )
 
-        with self.assertRaises(UntypyTypeError):
+        with self.assertRaises(UntypyTypeError) as cm:
             list(self.keyerr.items())
 
-        with self.assertRaises(UntypyTypeError):
+        with self.assertRaises(UntypyTypeError) as cm:
             list(self.valerr.items())
 
     def test_keys(self):

--- a/python/deps/untypy/test/impl/test_interface_set.py
+++ b/python/deps/untypy/test/impl/test_interface_set.py
@@ -1,0 +1,82 @@
+import unittest
+
+from test.util_test.untypy_test_case import UntypyTestCase, dummy_caller
+from untypy.error import UntypyTypeError
+
+
+class TestInterfaceSet(UntypyTestCase):
+    """
+    Test's that the signatures matches the implementation.
+    """
+
+    def setUp(self) -> None:
+        self.good = dummy_caller(
+            set[int],
+            {1, 2, 3}
+        )
+
+        self.bad = dummy_caller(
+            set[int],
+            {1, "two", 3}
+        )
+
+    def test_add(self):
+        self.good.add(4)
+
+        with self.assertRaises(UntypyTypeError):
+            self.good.add("four")
+
+    def test_discard(self):
+        self.good.discard(3)
+
+        with self.assertRaises(UntypyTypeError):
+            self.good.discard("four")
+
+    def test_pop(self):
+        self.good.pop()
+        self.good.pop()
+        self.good.pop()
+
+        with self.assertRaises(KeyError):
+            self.good.pop()
+            pass
+
+        with self.assertRaises(UntypyTypeError):
+            self.bad.pop()
+            self.bad.pop()
+            self.bad.pop()
+
+    def test_remove(self):
+        self.good.remove(3)
+
+        with self.assertRaises(UntypyTypeError):
+            self.good.remove("four")
+
+    def test_update(self):
+        self.good.update({5, 6, 7})
+        self.good.update({8}, [9], {24})
+
+        with self.assertRaises(UntypyTypeError):
+            self.good.update({"four"})
+
+    @unittest.skip("fails :/. Does not raise UntypyTypeError")
+    def test_ior(self):
+        self.good |= {4} | {7}
+        self.assertEqual(self.good, {1, 2, 3, 4, 7})
+
+        with self.assertRaises(UntypyTypeError):
+            self.good |= {"four"}
+
+    def test_contains(self):
+        self.assertEqual(1 in self.good, True)
+
+        with self.assertRaises(UntypyTypeError):
+            "four" in self.good
+
+    def test_iter(self):
+        for k in self.good:
+            pass
+
+        with self.assertRaises(UntypyTypeError):
+            for k in self.bad:
+                pass

--- a/python/deps/untypy/test/util_test/untypy_test_case.py
+++ b/python/deps/untypy/test/util_test/untypy_test_case.py
@@ -1,0 +1,29 @@
+import unittest
+
+import untypy
+from untypy.error import Location
+
+
+def dummy_caller_2(ch, arg):
+    return ch(arg)
+
+
+def dummy_caller(typ, arg):
+    """
+    Sets up callstack so that this function is blamed for creation.
+    untypy.checker uses the function that called the function that
+    invokes the checker.
+    """
+    ch = untypy.checker(lambda ty=typ: ty, dummy_caller)
+    return dummy_caller_2(ch, arg)
+
+
+class UntypyTestCase(unittest.TestCase):
+
+    def assertBlame(self, cm, blamed):
+        ok = cm.exception.last_responsable() in Location.from_code(blamed)
+        if not ok:
+            print(cm.exception.last_responsable())
+            print("not in")
+            print(Location.from_code(blamed))
+        self.assertTrue(ok)

--- a/python/deps/untypy/untypy/error.py
+++ b/python/deps/untypy/untypy/error.py
@@ -115,7 +115,11 @@ class Location:
                     line_span=1
                 )
 
-    def narrow_in_span(self, reti_loc : Tuple[str, int]):
+    def __contains__(self, other: Location):
+        file, line = (other.file, other.line_no)
+        return self.file == file and line in range(self.line_no, self.line_no + self.line_span)
+
+    def narrow_in_span(self, reti_loc: Tuple[str, int]):
         """
         Use new Location if inside of span of this Location
         :param reti_loc: filename and line_no

--- a/python/deps/untypy/untypy/impl/interface.py
+++ b/python/deps/untypy/untypy/impl/interface.py
@@ -15,7 +15,10 @@ V = TypeVar("V")
 class WDict(Generic[K, V], dict):
     def clear(self) -> None:
         pass
-    # TODO: def copy(self):
+
+    # Cannot Typecheck Copy -> Leads to endless recursion in "UntypyInterfaces"
+    # def copy(self) -> dict[K,V]:
+    #     pass
 
     def get(self, key : K, default: Optional[V] = None) -> Optional[V]:
         pass
@@ -32,10 +35,12 @@ class WDict(Generic[K, V], dict):
     def popitem(self) -> Tuple[K,V]:
         pass
 
-    def setdefault(self, key : K, default : Optional[V] = None) -> Optional[V]: # real signature unknown
+    # Miss-match See: https://github.com/skogsbaer/write-your-python-program/issues/19
+    def setdefault(self, key : K, default : V) -> V:
         pass
 
-    # TODO: def update(self, E=None, **F): # known special case of dict.update
+    # Missing var-arg support :/
+    # def update(self, E=None, **F) -> ???:
 
     def values(self) -> Iterable[V]:
         pass
@@ -46,20 +51,21 @@ class WDict(Generic[K, V], dict):
     def __delitem__(self, k : K) -> None:
         pass
 
-    def __iter__(self) -> Iterator[Tuple[K,V]]:
+    def __iter__(self) -> Iterator[K]:
         pass
 
     def __len__(self) -> int:
         pass
 
-    # TODO: def __or__(self, *args, **kwargs): # real signature unknown
-    #     """ Return self|value. """
+    # Untypy does not support generic functions :/
+    # def __or__(self, other : dict[I, J]) -> dict[Union[K,I], Union[V,J]]:
     #     pass
 
     def __reversed__(self) -> Iterator[K]:
         pass
 
-    # TODO: def __ror__(self, *args, **kwargs): # real signature unknown
+    # Untypy does not support generic functions :/
+    # def __ror__(self, other : dict[I, J]) -> dict[Union[K,I], Union[V,J]]:
     #     """ Return value|self. """
     #     pass
 
@@ -67,9 +73,6 @@ class WDict(Generic[K, V], dict):
         pass
 
     def __setitem__(self, key: K, value: V) -> None:
-        pass
-
-    def __delitem__(self, key) -> None:
         pass
 
 

--- a/python/deps/untypy/untypy/impl/interface.py
+++ b/python/deps/untypy/untypy/impl/interface.py
@@ -45,7 +45,7 @@ class WDict(Generic[K, V], dict):
     def values(self) -> Iterable[V]:
         pass
 
-    def __contains__(self, k : K) -> bool:
+    def __contains__(self, key: K) -> bool:
         pass
 
     def __delitem__(self, k : K) -> None:

--- a/python/deps/untypy/untypy/impl/interface.py
+++ b/python/deps/untypy/untypy/impl/interface.py
@@ -29,7 +29,7 @@ class WDict(Generic[K, V], dict):
     def keys(self) -> Iterable[K]:
         pass
 
-    def pop(self, k : K, default: Optional[V] = None) -> Optional[V]:
+    def pop(self, k: K, default: Optional[V] = None) -> Optional[V]:
         pass
 
     def popitem(self) -> Tuple[K,V]:

--- a/python/deps/untypy/untypy/impl/interface.py
+++ b/python/deps/untypy/untypy/impl/interface.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator, Iterable
-from typing import TypeVar, Optional, Any, Generic, Dict, List, Set
+from typing import TypeVar, Optional, Any, Generic, Dict, List, Set, Tuple
 
 from untypy.error import UntypyAttributeError, UntypyTypeError
 from untypy.impl.protocol import ProtocolChecker
@@ -11,11 +11,65 @@ K = TypeVar("K")
 V = TypeVar("V")
 
 
+# See: https://docs.python.org/3/library/stdtypes.html#typesmapping
 class WDict(Generic[K, V], dict):
+    def clear(self) -> None:
+        pass
+    # TODO: def copy(self):
+
+    def get(self, key : K, default: Optional[V] = None) -> Optional[V]:
+        pass
+
+    def items(self) -> Iterable[Tuple[K, V]]:
+        pass
+
+    def keys(self) -> Iterable[K]:
+        pass
+
+    def pop(self, k : K, default: Optional[V] = None) -> Optional[V]:
+        pass
+
+    def popitem(self) -> Tuple[K,V]:
+        pass
+
+    def setdefault(self, key : K, default : Optional[V] = None) -> Optional[V]: # real signature unknown
+        pass
+
+    # TODO: def update(self, E=None, **F): # known special case of dict.update
+
+    def values(self) -> Iterable[V]:
+        pass
+
+    def __contains__(self, k : K) -> bool:
+        pass
+
+    def __delitem__(self, k : K) -> None:
+        pass
+
+    def __iter__(self) -> Iterator[Tuple[K,V]]:
+        pass
+
+    def __len__(self) -> int:
+        pass
+
+    # TODO: def __or__(self, *args, **kwargs): # real signature unknown
+    #     """ Return self|value. """
+    #     pass
+
+    def __reversed__(self) -> Iterator[K]:
+        pass
+
+    # TODO: def __ror__(self, *args, **kwargs): # real signature unknown
+    #     """ Return value|self. """
+    #     pass
+
     def __getitem__(self, item: K) -> V:
         pass
 
     def __setitem__(self, key: K, value: V) -> None:
+        pass
+
+    def __delitem__(self, key) -> None:
         pass
 
 

--- a/python/deps/untypy/untypy/impl/interface.py
+++ b/python/deps/untypy/untypy/impl/interface.py
@@ -48,7 +48,7 @@ class WDict(Generic[K, V], dict):
     def __contains__(self, key: K) -> bool:
         pass
 
-    def __delitem__(self, k : K) -> None:
+    def __delitem__(self, key : K) -> None:
         pass
 
     def __iter__(self) -> Iterator[K]:

--- a/python/deps/untypy/untypy/impl/interface.py
+++ b/python/deps/untypy/untypy/impl/interface.py
@@ -91,11 +91,76 @@ I = TypeVar("I")
 
 
 class WSet(Generic[I], set):
+
+    def add(self, other: I) -> None:
+        pass
+
+    def clear(self) -> None:
+        pass
+
+    def discard(self, elem: I):
+        pass
+
+    def pop(self) -> I:
+        pass
+
+    def remove(self, elem: I) -> None:
+        pass
+
+    def update(self, *others: Tuple[Iterable[I], ...]) -> None:
+        pass
+
+    # This method returns `NotImplemented`, i don't know why.
+    def __ior__(self, *others: Tuple[Iterable[I], ...]) -> Any:
+        pass
+
     def __contains__(self, item: I) -> bool:
         pass
 
-    def add(self, elem: I) -> None:
+    def __iter__(self) -> Iterator[I]:
         pass
+
+    def __len__(self) -> int:
+        pass
+
+    # Only removes elements. No checking needed. Argument type is set Any
+    #
+    # def intersection_update(self, others: Iterator[set[Any]]) -> None:
+    #     pass
+    #
+    # def __iand__(self, other: set[Any]) -> None:
+    #     pass
+    #
+    # def difference_update(self, others: Iterator[set[Any]]) -> None:
+    #     pass
+    #
+    # def __isub__(self, other: set[Any]) -> None:
+    #     pass
+
+    # Mutable meth
+    # symmetric_difference_update
+    # __ixor__
+
+    # Recursion
+    # copy
+
+    # Immutable generic meth
+    # difference
+    # intersection
+    # isdisjoint
+    # issubset
+    # issuperset
+    # symmetric_difference(self, other)
+    # union(self, other)
+    # __and__
+    # __or__
+    # __rand__
+    # __reduce__ ???
+    # __ror__
+    # __rsub__
+    # __rxor__
+    # __sub__
+    # __xor__
 
 
 I = TypeVar("I")
@@ -104,6 +169,7 @@ I = TypeVar("I")
 class WIterable(Generic[I]):
     def __iter__(self) -> Iterator[I]:
         pass
+
 
 InterfaceMapping = {
     dict: (WDict,),
@@ -115,6 +181,7 @@ InterfaceMapping = {
     Iterable: (WIterable,),
 }
 
+InterfaceFactoryCache = {}
 
 class InterfaceFactory(TypeCheckerFactory):
 
@@ -145,7 +212,6 @@ class InterfaceFactory(TypeCheckerFactory):
             else:
                 # type(origin) == collection.abc.ABCMeta
                 return ProtocolChecker(protocol, ctx, altname=name)
-
         else:
             return None
 

--- a/python/deps/untypy/untypy/impl/wrappedclass.py
+++ b/python/deps/untypy/untypy/impl/wrappedclass.py
@@ -121,7 +121,6 @@ class WrappedClassFunction(WrappedFunction):
         self.checker = checker
         self.create_fn = create_fn
         self._declared = declared
-
         self.fc = None
         if hasattr(self.inner, "__fc"):
             self.fc = getattr(self.inner, "__fc")
@@ -133,7 +132,7 @@ class WrappedClassFunction(WrappedFunction):
         def wrapper_cls(*args, **kwargs):
             caller = sys._getframe(1)
             (args, kwargs, bindings) = self.wrap_arguments(
-                lambda n: ArgumentExecutionContext(self, caller, n, declared=self.declared()),
+                lambda n: ArgumentExecutionContext(wrapper_cls, caller, n, declared=self.declared()),
                 args, kwargs)
             ret = fn(*args, **kwargs)
             return self.wrap_return(ret, bindings, ReturnExecutionContext(self))
@@ -144,7 +143,7 @@ class WrappedClassFunction(WrappedFunction):
                 me.__inner = self.create_fn()
             caller = sys._getframe(1)
             (args, kwargs, bindings) = self.wrap_arguments(
-                lambda n: ArgumentExecutionContext(self, caller, n, declared=self.declared()),
+                lambda n: ArgumentExecutionContext(wrapper_self, caller, n, declared=self.declared()),
                 (me.__inner, *args), kwargs)
             ret = fn(*args, **kwargs)
             if me.__return_ctx is None:

--- a/python/deps/untypy/untypy/util/__init__.py
+++ b/python/deps/untypy/untypy/util/__init__.py
@@ -146,6 +146,7 @@ def format_name(orig):
             return f"{k} constructor {n}"
     return n
 
+
 class ArgumentExecutionContext(ExecutionContext):
     n: WrappedFunction
     stack: inspect.FrameInfo
@@ -166,7 +167,11 @@ class ArgumentExecutionContext(ExecutionContext):
         error_id = IndicatorStr(next_ty, indicator)
 
         original = WrappedFunction.find_original(self.fn)
-        signature = inspect.signature(original)
+        try:
+            signature = inspect.signature(original)
+        except ValueError:
+            # fails on some built-ins
+            signature = inspect.signature(self.fn)
 
         wf = None
         if (hasattr(self.fn, '__wf')):


### PR DESCRIPTION
closes #19 
closes #20 
closes #23 

For details see #19 / #20

Typechecking for `__ior__` ( `a |= b`) for sets does currently not work.
`update` performs the same operation, but works. However it is implement using the same method.
It tried debugging, but I cannot step through the C implementation of `__ior__`. 
Somehow this method returns `NotImplemented`.
When looking at the C Code of Python it seems like this branch was triggert, however this cannot be the case, as the set gets updated.
```c
    if (!PyAnySet_Check(other))
        Py_RETURN_NOTIMPLEMENTED;
```
https://github.com/python/cpython/blob/1dbf9c86b25463b9bc695e434ac034a7e313ba01/Objects/setobject.c#L1171

I will create an issue for this. Maybe it can be solved using some more debugging, or an workaround can be used. Perhaps this workaround could also be for the currently unchecked functions in `dict`/`set`.