### PR TITLE
Allow usage of strings as foward refs #64

### DIFF
--- a/python/deps/untypy/untypy/impl/string_forward_refs.py
+++ b/python/deps/untypy/untypy/impl/string_forward_refs.py
@@ -1,0 +1,14 @@
+from typing import Any, Optional
+
+from untypy.interfaces import TypeChecker, TypeCheckerFactory, CreationContext
+
+
+class StringForwardRefFactory(TypeCheckerFactory):
+    def create_from(self, annotation: Any, ctx: CreationContext) -> Optional[TypeChecker]:
+        if type(annotation) is str:
+            eval_args = [annotation, globals()]
+            local = ctx.eval_context()
+            if local is not None:
+                eval_args.append(local)
+            annotation = eval(*eval_args)
+            return ctx.find_checker(annotation)

--- a/python/deps/untypy/untypy/interfaces.py
+++ b/python/deps/untypy/untypy/interfaces.py
@@ -28,6 +28,9 @@ class CreationContext:
     def should_be_inheritance_checked(self, annotation: type) -> bool:
         raise NotImplementedError
 
+    def eval_context(self):
+        raise NotImplementedError
+
 
 class ExecutionContext:
     def wrap(self, err: UntypyTypeError) -> UntypyTypeError:

--- a/python/deps/untypy/untypy/patching/__init__.py
+++ b/python/deps/untypy/untypy/patching/__init__.py
@@ -38,7 +38,6 @@ def patch_class(clas: type, cfg: Config):
                 line_no=0,
                 line_span=1
             ), checkedpkgprefixes=cfg.checkedprefixes,
-            eval_context=vars(clas.__module__),
         )
 
     setattr(clas, '__patched', True)
@@ -66,4 +65,4 @@ def wrap_class(a: type, cfg: Config) -> Callable:
     return WrappedType(a, DefaultCreationContext(
         typevars=dict(),
         declared_location=Location.from_code(a),
-        checkedpkgprefixes=cfg.checkedprefixes, eval_context=vars(a.__module__)))
+        checkedpkgprefixes=cfg.checkedprefixes))

--- a/python/deps/untypy/untypy/patching/__init__.py
+++ b/python/deps/untypy/untypy/patching/__init__.py
@@ -37,7 +37,9 @@ def patch_class(clas: type, cfg: Config):
                 file="<not found>",
                 line_no=0,
                 line_span=1
-            ), checkedpkgprefixes=cfg.checkedprefixes)
+            ), checkedpkgprefixes=cfg.checkedprefixes,
+            eval_context=vars(clas.__module__),
+        )
 
     setattr(clas, '__patched', True)
 
@@ -55,7 +57,7 @@ def wrap_function(fn: FunctionType, cfg: Config) -> Callable:
         return TypedFunctionBuilder(fn, DefaultCreationContext(
             typevars=dict(),
             declared_location=WrappedFunction.find_location(fn),
-            checkedpkgprefixes=cfg.checkedprefixes)).build()
+            checkedpkgprefixes=cfg.checkedprefixes, eval_context=fn.__globals__)).build()
     else:
         return fn
 
@@ -64,4 +66,4 @@ def wrap_class(a: type, cfg: Config) -> Callable:
     return WrappedType(a, DefaultCreationContext(
         typevars=dict(),
         declared_location=Location.from_code(a),
-        checkedpkgprefixes=cfg.checkedprefixes))
+        checkedpkgprefixes=cfg.checkedprefixes, eval_context=vars(a.__module__)))

--- a/python/fileTests
+++ b/python/fileTests
@@ -141,6 +141,7 @@ checkWithOutputAux yes 0 test-data/testForwardRef1.py
 checkWithOutputAux yes 1 test-data/testForwardRef2.py
 checkWithOutputAux yes 0 test-data/testForwardRef3.py
 checkWithOutputAux yes 1 test-data/testForwardRef4.py
+checkWithOutputAux yes 0 test-data/testForwardRef4.py
 checkWithOutputAux yes 1 test-data/testTypesReturn.py
 checkWithOutputAux yes 1 test-data/testMissingReturn.py
 checkWithOutputAux yes 1 test-data/testTypesSequence1.py

--- a/python/fileTests
+++ b/python/fileTests
@@ -141,7 +141,7 @@ checkWithOutputAux yes 0 test-data/testForwardRef1.py
 checkWithOutputAux yes 1 test-data/testForwardRef2.py
 checkWithOutputAux yes 0 test-data/testForwardRef3.py
 checkWithOutputAux yes 1 test-data/testForwardRef4.py
-checkWithOutputAux yes 0 test-data/testForwardRef4.py
+checkWithOutputAux yes 1 test-data/testForwardRef5.py
 checkWithOutputAux yes 1 test-data/testTypesReturn.py
 checkWithOutputAux yes 1 test-data/testMissingReturn.py
 checkWithOutputAux yes 1 test-data/testTypesSequence1.py

--- a/python/test-data/testForwardRef5.err
+++ b/python/test-data/testForwardRef5.err
@@ -1,0 +1,12 @@
+Traceback (most recent call last):
+  File "test-data/testForwardRef5.py", line 23, in <module>
+    for car in garage.cars:
+WyppTypeError: got value of wrong type
+given:    'Not A Car'
+expected: value of type Car
+
+context: record constructor Garage(cars: list[Car]) -> Self
+                                              ^^^
+declared at: test-data/testForwardRef5.py:9
+caused by: test-data/testForwardRef5.py:23
+  | for car in garage.cars:

--- a/python/test-data/testForwardRef5.py
+++ b/python/test-data/testForwardRef5.py
@@ -1,0 +1,24 @@
+# See https://github.com/skogsbaer/write-your-python-program/issues/62
+
+from wypp import *
+
+@record
+class Car:
+    color: str
+
+@record
+class Garage:
+    cars: list['Car']
+
+class CarManager:
+    def store(self, car : set['Car'], garage :'Garage') -> 'CarManager':
+        return self
+
+garage = Garage(cars=[Car(color='red'), Car(color='blue')])
+for car in garage.cars:
+    pass
+
+# trigger error
+garage = Garage(cars=[Car(color='red'), "Not A Car"])
+for car in garage.cars:
+    pass


### PR DESCRIPTION
* strings can be used as foward refs inside other types
* context of the function is passed to `eval` when resolving
+ added code in #64 as test


--
closes #62 