### PR TITLE
Checking of unimplemented abstract method is broken

### DIFF
--- a/python/deps/untypy/untypy/util/typedfunction.py
+++ b/python/deps/untypy/untypy/util/typedfunction.py
@@ -99,6 +99,13 @@ class TypedFunctionBuilder(WrappedFunction):
         setattr(w, '__name__', self.inner.__name__)
         setattr(w, '__signature__', self.signature)
         setattr(w, '__wf', self)
+
+        # Copy useful attributes
+        # This is need for the detection of abstract classes
+        for attr in ['__isabstractmethod__']:
+            if hasattr(self.inner, attr):
+                setattr(w, attr, getattr(self.inner, attr))
+
         return w
 
     def wrap_arguments(self, ctxprv: WrappedFunctionContextProvider, args, kwargs):

--- a/python/fileTests
+++ b/python/fileTests
@@ -123,6 +123,7 @@ checkWithOutput 0 test-data/printModuleName.py
 checkWithOutput 0 test-data/printModuleNameImport.py
 checkWithOutput 1 test-data/testTypes1.py
 checkWithOutput 1:0 test-data/testTypes2.py
+checkWithOutputAux yes 1 test-data/testABCMeta.py
 checkWithOutputAux yes 1 test-data/testTypesCollections1.py
 checkWithOutputAux yes 1 test-data/testTypesCollections2.py
 # checkWithOutputAux yes 1 test-data/testTypesCollections3.py  See #5

--- a/python/test-data/testABCMeta.err
+++ b/python/test-data/testABCMeta.err
@@ -1,0 +1,4 @@
+Traceback (most recent call last):
+  File "test-data/testABCMeta.py", line 28, in <module>
+    Circle(Point(0, 0), 1)
+TypeError: Can't instantiate abstract class Circle with abstract method area

--- a/python/test-data/testABCMeta.py
+++ b/python/test-data/testABCMeta.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+# See: https://github.com/skogsbaer/write-your-python-program/issues/74
+
+from wypp import *
+import abc
+
+class Shape(abc.ABC):
+    def __init__(self, center: Point)->None:
+        self.center = center
+    @abc.abstractmethod
+    def area(self) -> float:
+        pass
+
+class Circle(Shape):
+    def __init__(self, center: Point, radius: float)->None:
+        super().__init__(center)
+        self.radius = float
+    # no implementation of area!
+
+@dataclass
+class Point:
+    x: float
+    y: float
+    def move(self, x: float, y: float)->None:
+        self.x = self.x + x
+        self.y = self.y + y
+
+Circle(Point(0, 0), 1)


### PR DESCRIPTION
fixes #74 

Although ABCMeta performs some C Magic, there is an surprisingly easy fix. Re-adding `__isabstractmethod__` to the wrapped function is enough.


  