### PR TITLE
 str(type(x)) should return the original string

### DIFF
--- a/python/deps/untypy/untypy/impl/protocol.py
+++ b/python/deps/untypy/untypy/impl/protocol.py
@@ -231,7 +231,13 @@ def ProtocolWrapper(protocolchecker: ProtocolChecker, originalValue: Any,
     list_of_attr['__getattr__'] = __getattr__  # allow access of attributes
     list_of_attr['__setattr__'] = __setattr__  # allow access of attributes
     name = f"{protocolchecker.proto.__name__}For{original.__name__}"
-    return type(name, (), list_of_attr)
+    t = type(name, (), list_of_attr)
+
+    # Copy attributes for print right name
+    for attr in ['__module__', '__name__', '__qualname__']:
+        if hasattr(original, attr):
+            setattr(t, attr, getattr(original, attr))
+    return t
 
 
 class ProtocolWrappedFunction(WrappedFunction):

--- a/python/fileTests
+++ b/python/fileTests
@@ -173,4 +173,5 @@ checkWithOutputAux yes 0 test-data/testComplex.py
 checkWithOutputAux yes 0 test-data/testUnionLiteral.py
 checkWithOutputAux yes 0 test-data/testCheck.py
 checkWithOutputAux yes 0 test-data/testNameErrorBug.py
+checkWithOutputAux yes 0 test-data/testOriginalTypeNames.py 
 checkWithOutputAux yes 0 test-data/testDeepEqBug.py

--- a/python/test-data/testOriginalTypeNames.out
+++ b/python/test-data/testOriginalTypeNames.out
@@ -1,0 +1,1 @@
+<class 'generator'>

--- a/python/test-data/testOriginalTypeNames.py
+++ b/python/test-data/testOriginalTypeNames.py
@@ -1,0 +1,10 @@
+from wypp import *
+# See: https://github.com/skogsbaer/write-your-python-program/issues/76
+
+def myRange(n: int) -> Iterable[int]:
+    i = 0
+    while i < n:
+        yield i
+        i = i + 1
+
+print(type(myRange(5)))


### PR DESCRIPTION
closes #76 

this is done by setting `__qualname__`, `__name__` and `__module__` of newly created type.

This could intervene in source code retrieval and make debugging harder.
Note: `__repr__` or `__str__` can only be implemented for Instances, but not for classes. 