### PR TITLE
add LockFactory to WYPP

### DIFF
--- a/python/deps/untypy/untypy/impl/annotated.py
+++ b/python/deps/untypy/untypy/impl/annotated.py
@@ -1,7 +1,7 @@
 from typing import Optional, Any, Iterator
 
 from untypy.error import UntypyTypeError, UntypyAttributeError, Frame
-from untypy.interfaces import TypeCheckerFactory, TypeChecker, ExecutionContext, CreationContext, WrappedFunction
+from untypy.interfaces import TypeCheckerFactory, TypeChecker, ExecutionContext, CreationContext
 
 
 class AnnotatedChecker:
@@ -124,6 +124,8 @@ class AnnotatedCheckerExecutionContext(ExecutionContext):
         offset = self.ch.describe().find("[") + 1
 
         (t, i) = err.next_type_and_indicator()
+        if self.ch.name is not None:
+            i = "^" * len(self.ch.describe())
 
         err = err.with_frame(Frame(
             type_declared=self.ch.describe(),

--- a/python/fileTests
+++ b/python/fileTests
@@ -176,3 +176,4 @@ checkWithOutputAux yes 0 test-data/testUnionLiteral.py
 checkWithOutputAux yes 0 test-data/testCheck.py
 checkWithOutputAux yes 0 test-data/testNameErrorBug.py
 checkWithOutputAux yes 0 test-data/testDeepEqBug.py
+checkWithOutputAux yes 1 test-data/testLockFactory.py

--- a/python/src/__init__.py
+++ b/python/src/__init__.py
@@ -10,6 +10,7 @@ Literal = w.Literal
 Mapping = w.Mapping
 Optional = w.Optional
 Sequence = w.Sequence
+Protocol = w.Protocol
 Union = w.Union
 check = w.check
 dataclass = w.dataclass
@@ -24,6 +25,8 @@ intPositive = w.intPositive
 math = w.math
 nat = w.nat
 record = w.record
+LockLike = w.LockLike
+LockFactory = w.LockFactory
 T = w.T
 U = w.U
 unchecked = w.unchecked
@@ -39,6 +42,7 @@ __all__ = [
     'Mapping',
     'Optional',
     'Sequence',
+    'Protocol',
     'Union',
     'check',
     'dataclass',
@@ -53,6 +57,8 @@ __all__ = [
     'math',
     'nat',
     'record',
+    'LockLike',
+    'LockFactory',
     'T',
     'U',
     'unchecked',

--- a/python/src/writeYourProgram.py
+++ b/python/src/writeYourProgram.py
@@ -19,6 +19,7 @@ Iterator = typing.Iterator
 Sequence = typing.Sequence
 Generator = typing.Generator
 ForwardRef = typing.ForwardRef
+Protocol = typing.Protocol
 
 Mapping = typing.Mapping
 
@@ -38,6 +39,18 @@ floatPositive = typing.Annotated[float, lambda x: x > 0, 'floatPositive']
 floatNonNegative = typing.Annotated[float, lambda x: x >= 0, 'floatNonNegative']
 floatNegative = typing.Annotated[float, lambda x: x < 0, 'floatNegative']
 floatNonPositive = typing.Annotated[float, lambda x: x <= 0, 'floatNonPositive']
+
+class LockLike(Protocol):
+    def acquire(self, blocking: bool = True, timeout:int = -1) -> Any:
+       pass
+
+    def release(self) -> Any:
+        pass
+
+    def locked(self) -> Any:
+        pass
+
+LockFactory = typing.Annotated[Callable[[], LockLike], 'LockFactory']
 
 T = typing.TypeVar('T')
 U = typing.TypeVar('U')

--- a/python/test-data/testLockFactory.err
+++ b/python/test-data/testLockFactory.err
@@ -1,0 +1,12 @@
+Traceback (most recent call last):
+  File "test-data/testLockFactory.py", line 15, in <module>
+    foo("not a lock")
+WyppTypeError: got value of wrong type
+given:    'not a lock'
+expected: value of type Callable[[], LockLike]
+
+context: foo(lock: LockFactory) -> None
+                   ^^^^^^^^^^^
+declared at: test-data/testLockFactory.py:6
+caused by: test-data/testLockFactory.py:15
+  | foo("not a lock")

--- a/python/test-data/testLockFactory.py
+++ b/python/test-data/testLockFactory.py
@@ -1,0 +1,15 @@
+from wypp import *
+
+import threading
+# See: https://github.com/skogsbaer/write-your-python-program/issues/77
+
+def foo(lock: LockFactory) -> None:
+    l = lock()
+    l.acquire()
+    # ...
+    l.release()
+    pass
+
+foo(threading.Lock)
+# ...
+foo("not a lock")


### PR DESCRIPTION
closes #77  

```
Traceback (most recent call last):
  File "test-data/testLockFactory.py", line 15, in <module>
    foo("not a lock")
WyppTypeError: got value of wrong type
given:    'not a lock'
expected: value of type Callable[[], LockLike]

context: foo(lock: LockFactory) -> None
                   ^^^^^^^^^^^
declared at: test-data/testLockFactory.py:6
caused by: test-data/testLockFactory.py:15
  | foo("not a lock")
```