### PR TITLE
fix and test #92

### DIFF
--- a/python/deps/untypy/test/impl/test_list.py
+++ b/python/deps/untypy/test/impl/test_list.py
@@ -107,6 +107,13 @@ class TestList(unittest.TestCase):
         self.assertEqual(self.wrapped_list[1], 1)
         self.assertEqual(self.wrapped_list[:], [0, 1, 2, 3])
         self.assertEqual(self.wrapped_list[1:], [1, 2, 3])
+
+        # Index
+        self.assertEqual(self.wrapped_list.index(1), 1)
+        self.assertEqual(self.wrapped_list.index(1, 0, 2), 1)
+        self.assertRaises(ValueError, lambda: self.wrapped_list.index(2, start=3))  # Value Error '2' not in list
+        self.assertRaises(UntypyTypeError, lambda: self.wrapped_list.index("hello"))  # Wrong Argument Type
+
         self.wrapped_list.append(4)
         self.assertEqual(self.wrapped_list, [0, 1, 2, 3, 4])
 

--- a/python/deps/untypy/untypy/impl/interfaces/list.py
+++ b/python/deps/untypy/untypy/impl/interfaces/list.py
@@ -45,7 +45,7 @@ class List(Generic[I], list):
     def clear(self) -> None:
         pass
 
-    def index(self, value: I, start: Optional[int] = None, stop: Optional[int] = None) -> int:
+    def index(self, value: I, start: Optional[int] = 0, stop: Optional[int] = 9223372036854775807) -> int:
         # get index of list
         pass
 


### PR DESCRIPTION
closes #92

I looked into it. Since  #64  untypy uses (impl/interfaces/list.py)[https://github.com/skogsbaer/write-your-python-program/blob/master/python/deps/untypy/untypy/impl/interfaces/list.py] for function signatures of list. The wrappers are generated using `untypy/impl/interface.py`, instead of writing the wrappers manually. Replacing `start` and `stop` in the interface definition fixes the bug. 
