### PR TITLE
Feature/106 signatureless methods

### DIFF
--- a/python/fileTests
+++ b/python/fileTests
@@ -250,3 +250,4 @@ checkWithOutputAux yes 0 test-data/testIterator3.py
 checkWithOutputAux yes 0 test-data/testIterator4.py
 checkWithOutputAux yes 0 test-data/testConcat.py
 checkWithOutputAux yes 0 test-data/testCopy.py
+checkWithOutputAux yes 0 test-data/testCopy2.py

--- a/python/test-data/testCopy2.out
+++ b/python/test-data/testCopy2.out
@@ -1,0 +1,3 @@
+d1: {'foo': 1, 'bar': 2}
+d2: {'foo': 1, 'bar': 2}
+2 Tests, alle erfolgreich :-)

--- a/python/test-data/testCopy2.py
+++ b/python/test-data/testCopy2.py
@@ -1,0 +1,12 @@
+# https://github.com/skogsbaer/write-your-python-program/issues/106
+from wypp import *
+
+def wrapDict(d: dict[str, int]) -> Any:
+    return d
+
+d1 = {"foo": 1, "bar": 2}
+d2 = wrapDict(d1).copy()
+check(d1 is d2, False)
+check(d1 == d2, True)
+print(f"d1: {d1}")
+print(f"d2: {d2}")


### PR DESCRIPTION
fixes #106 

The wrapper for Dicts, etc... now uses a dummy signature on signatureless methods (some python built-ins).
The previous behavior for those methods was:
 - `<instance of wrapper for dict>.copy()` would retrieve the `copy` attribute of the inner (`<instance of dict>.copy`). 
 - This retrieve would incorrectly bind <instance of wrapper for dict> as self in the returned method because of some python magic. (The the inner should have been bind as self). 
 - `copy` would than be called with wrapper as self.
Now:
- `WrappedType` creates a wrapped version of for these methods with signature `(self, *args: Any, **kwargs: Any)->Any`.

That fixes issues with dict.copy()
