### PR TITLE
Read files for visualization with utf-8 encoding

### DIFF
--- a/pytrace-generator/main.py
+++ b/pytrace-generator/main.py
@@ -428,7 +428,7 @@ if len(sys.argv) <= 1:
     exit(1)
 
 filename = os.path.abspath(sys.argv[1])
-with open(filename, "r") as f:
+with open(filename, "r", encoding="utf-8") as f:
     script_str = f.read()
 
 # Add a 'pass' at the end to also get the last trace step


### PR DESCRIPTION
Without explicitly setting the encoding when calling `open`, calling `compile` might fail (usually on Windows). This would be the case, for example, when a variable name contains the letter 'ß'.