### PR TITLE
Also detect import* in visualization

### DIFF
--- a/pytrace-generator/main.py
+++ b/pytrace-generator/main.py
@@ -16,7 +16,7 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 type_name_regex = re.compile("<class '(?:__main__\\.)?(.*)'>")
-import_regex = re.compile(r"^(?:[^'\"]+\s)?import ")
+import_regex = re.compile(r"^(?:[^'\"]+\s)?import[\s*]")
 
 # Frame objects:
 # https://docs.python.org/3/reference/datamodel.html#frame-objects


### PR DESCRIPTION
With this fix, lines containing an `import*` will now also be considered as an import and the variables added to the stack through this line won't be shown.

Resolves #153